### PR TITLE
Make installer portable and safe across machines

### DIFF
--- a/.github/workflows/validate-shell.yml
+++ b/.github/workflows/validate-shell.yml
@@ -1,0 +1,25 @@
+name: Validate shell installer
+
+on:
+  push:
+    paths:
+      - "install.sh"
+      - "system-setup.sh"
+      - ".github/workflows/validate-shell.yml"
+  pull_request:
+    paths:
+      - "install.sh"
+      - "system-setup.sh"
+      - ".github/workflows/validate-shell.yml"
+
+jobs:
+  bash-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Bash syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash -n install.sh
+          bash -n system-setup.sh

--- a/README-INSTALLER.md
+++ b/README-INSTALLER.md
@@ -1,6 +1,6 @@
 # One-command installer
 
-This repository is designed for Arch/CachyOS with GNU Stow.
+This repository targets Arch/CachyOS + Hyprland and separates **portable dotfiles** from **machine-specific system state**.
 
 ## One command
 
@@ -10,30 +10,121 @@ Interactive install:
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/huzaifahshahid71-ops/dotfiles/main/install.sh)"
 ```
 
-Direct profiles:
+The interactive installer defaults to safe choices. It does **not** silently replace SDDM configuration, change the UEFI boot order, enable G16 display timings, change GPU mode, or configure hibernation.
+
+## Safe profiles
 
 ```bash
+# Portable Hyprland / Caelestia / Fish / mpv / scripts / user services
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/huzaifahshahid71-ops/dotfiles/main/install.sh)" -- --base
+
+# Generic ASUS support
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/huzaifahshahid71-ops/dotfiles/main/install.sh)" -- --asus
+
+# G16-safe extras (no GPU switch, no display timing changes)
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/huzaifahshahid71-ops/dotfiles/main/install.sh)" -- --g16
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/huzaifahshahid71-ops/dotfiles/main/install.sh)" -- --g16 --refind
+
+# Frieren SDDM theme only; does not enable/replace the display manager
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/huzaifahshahid71-ops/dotfiles/main/install.sh)" -- --sddm-theme
+
+# Portable base + automatically detected safe ASUS/G16 extras
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/huzaifahshahid71-ops/dotfiles/main/install.sh)" -- --all
 ```
 
+`--all` is intentionally **safe-all**, not "restore every captured machine setting".
+
+## Explicit machine-changing actions
+
+These are never run by `--base` or `--all`:
+
+```bash
+# Install/configure rEFInd for the current machine.
+# The installer detects the current ESP again after refind-install,
+# preserves the previous BootOrder unless you explicitly choose otherwise,
+# applies only the portable theme, and generates current-machine kernel options.
+./install.sh --refind
+
+# Enable the captured G16 120/240 Hz service.
+# Requires a detected G16 + active Hyprland + eDP-1 at 2560x1600.
+./install.sh --refresh
+
+# Configure Btrfs swap storage for hibernation.
+# This is explicit and does not silently edit bootloader resume parameters.
+./install.sh --hibernate
+
+# Exact captured SDDM restore.
+# Guarded by captured/current DMI model matching plus confirmation.
+./install.sh --sddm
+```
+
+If you deliberately need to apply an exact captured machine profile to a different model:
+
+```bash
+./install.sh --force-machine-profile --sddm
+```
+
+Use that override only when you understand the consequences.
+
+## Why the safety split exists
+
+`machine/` is a **backup of one specific machine**, not a portable installation profile.
+
+In particular:
+
+- `machine/sddm/` may contain display-manager/autologin/session state.
+- `machine/refind/` may contain bootloader settings and old kernel options.
+- `scripts/.local/bin/auto-refresh-rate` contains G16 panel-specific timings.
+- hibernation layout depends on the target filesystem and available storage.
+
+The portable installer therefore treats those as opt-in system actions instead of restoring them during the normal Stow phase.
+
+## rEFInd behavior
+
+The safe rEFInd path:
+
+1. verifies UEFI mode and refuses unsigned setup while Secure Boot is enabled;
+2. detects a mounted FAT ESP, preferring `/boot/efi`, then `/efi`, then `/boot`;
+3. saves the existing UEFI `BootOrder`;
+4. runs `refind-install` only when needed;
+5. **re-detects the ESP and `refind.conf` after installation**;
+6. applies the saved `rEFInd-minimal` theme without replacing target-machine boot entries;
+7. uses `mkrlconf` when available to generate target-machine Linux options;
+8. keeps the previous boot order unless the user explicitly chooses to make rEFInd first.
+
+The captured full `refind.conf` and captured hard-coded root device are not copied onto another machine.
+
+## SDDM behavior
+
+`--sddm-theme` copies the Frieren theme and writes only:
+
+```ini
+[Theme]
+Current=sddm-frieren-theme
+```
+
+It does **not**:
+
+- enable SDDM;
+- replace another display manager;
+- restore autologin;
+- overwrite the complete captured `/etc/sddm.conf`.
+
+The exact snapshot remains available through the explicit guarded `--sddm` action.
+
 ## Repository roles
 
-- `caelestia/` — DiM Caelestia user configuration
-- `fish/` — Fish configuration
+- `caelestia/` — portable DiM Caelestia user configuration
+- `fish/` — Fish configuration (`fish_variables` is not deployed)
 - `hypr/` — Hyprland configuration
 - `mpv/` — mpv/MPRIS configuration
 - `scripts/` — helper scripts under `~/.local/bin`
-- `systemd/` — user services
-- `machine/` — captured package lists, system metadata, and sanitized rEFInd backup
+- `systemd/` — user services; machine-specific services are not enabled automatically
+- `machine/` — captured package lists, system metadata, SDDM backup, sanitized rEFInd backup
 - `hardware/` — ASUS, Zephyrus G16, and rEFInd notes
-- `install.sh` — one-command bootstrap and Stow installer
-- `system-setup.sh` — capture/restore/hardware commands
+- `install.sh` — one-command safe bootstrap/installer
+- `system-setup.sh` — guarded machine/system actions
 
-## Capture current machine
+## Capture the current machine
 
 ```bash
 ./system-setup.sh capture
@@ -41,16 +132,14 @@ git status
 git diff
 ```
 
-`capture` synchronizes the user configs into the Stow packages, records
-official/AUR package lists, saves a sanitized rEFInd configuration and theme,
-and records machine metadata.
+Capture synchronizes the user configs, package lists, SDDM snapshot, sanitized rEFInd backup/theme, and machine metadata.
 
-The capture intentionally excludes:
+It intentionally excludes or sanitizes:
 
-- NVIDIA/CUDA packages and driver automation
-- Secure-Boot signing/tool automation
-- Fish universal variables
-- obvious `.env`, token, secret, credential and cache files
+- NVIDIA/CUDA package automation;
+- Secure-Boot signing automation;
+- Fish universal variables;
+- `.env`, token, secret, credential, cache, PID, lock and log files;
+- rEFInd `root=/dev/...` device paths (converted to a root UUID placeholder).
 
-The custom Quickshell development repo is **not** nested inside this dotfiles
-repository. Its origin/branch/commit are recorded in `machine/custom-shell.txt`.
+The custom Quickshell development repository is not nested inside this repository; only its origin/branch/commit metadata is recorded.

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 REPO_URL="${DOTFILES_REPO_URL:-https://github.com/huzaifahshahid71-ops/dotfiles.git}"
 DOTFILES_DIR="${DOTFILES_DIR:-$HOME/dotfiles}"
-SCRIPT_NAME="$(basename "$0")"
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()   { printf '\033[1;32m✓\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33mWARNING:\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
 
@@ -44,28 +44,14 @@ ensure_repo() {
         git clone "$REPO_URL" "$DOTFILES_DIR"
     fi
 
-    # If this is the curl-piped copy, hand off to the repository copy so all
-    # hardware/profile files are available.
+    # A curl-piped copy cannot see the rest of the repository. Hand execution
+    # to the checked-out copy before doing anything to the machine.
     local self_real repo_real
     self_real="$(readlink -f "$0" 2>/dev/null || true)"
     repo_real="$(readlink -f "$DOTFILES_DIR/install.sh" 2>/dev/null || true)"
     if [[ -n "$repo_real" && "$self_real" != "$repo_real" ]]; then
         exec "$DOTFILES_DIR/install.sh" "$@"
     fi
-}
-
-install_repo_pkg() {
-    local pkg
-    for pkg in "$@"; do
-        if pacman -Q "$pkg" >/dev/null 2>&1; then
-            continue
-        fi
-        if pacman -Si "$pkg" >/dev/null 2>&1; then
-            sudo pacman -S --needed "$pkg"
-        else
-            return 1
-        fi
-    done
 }
 
 ensure_aur_helper() {
@@ -116,6 +102,13 @@ backup_stow_conflicts() {
 
     while IFS= read -r -d '' file; do
         rel="${file#"$src/"}"
+
+        # fish_variables contains host/user-specific universal variables and is
+        # intentionally not deployed as a portable dotfile.
+        if [[ "$pkg" == "fish" && "$rel" == ".config/fish/fish_variables" ]]; then
+            continue
+        fi
+
         dst="$HOME/$rel"
         if [[ -e "$dst" && ! -L "$dst" ]]; then
             mkdir -p "$backup/$(dirname "$rel")"
@@ -125,18 +118,25 @@ backup_stow_conflicts() {
     done < <(find "$src" -type f -print0)
 }
 
+stow_portable_package() {
+    local pkg="$1"
+    [[ -d "$DOTFILES_DIR/$pkg" ]] || return 0
+    backup_stow_conflicts "$pkg"
+
+    if [[ "$pkg" == "fish" ]]; then
+        stow -d "$DOTFILES_DIR" -t "$HOME" --ignore='(^|/)fish_variables$' --restow "$pkg"
+    else
+        stow -d "$DOTFILES_DIR" -t "$HOME" --restow "$pkg"
+    fi
+}
 
 install_widgets() {
     local spec="${1:-}"
-    [[ -n "$spec" ]] || die "--widgets requires a comma-separated list: lyrics, visualiser, or lyrics,visualiser"
-
+    [[ -n "$spec" ]] || die "--widgets requires: lyrics, visualiser, or lyrics,visualiser"
     is_arch_family || die "The widget installer currently supports Arch/CachyOS only."
 
-    local want_lyrics=0
-    local want_visualiser=0
-    local item
+    local want_lyrics=0 want_visualiser=0 item
     local -a raw
-
     IFS=',' read -ra raw <<< "$spec"
     for item in "${raw[@]}"; do
         item="${item,,}"
@@ -148,7 +148,6 @@ install_widgets() {
             *) die "Unknown widget '$item'. Supported: lyrics, visualiser" ;;
         esac
     done
-
     (( want_lyrics || want_visualiser )) || die "No supported widgets were selected."
 
     log "Installing minimal Caelestia widget dependencies"
@@ -161,13 +160,11 @@ install_widgets() {
     fi
 
     local profile="$DOTFILES_DIR/widgets/caelestia-widget-profile.json"
-    [[ -f "$profile" ]] || die "Widget profile is missing from the repository: $profile"
+    [[ -f "$profile" ]] || die "Widget profile is missing: $profile"
 
-    local config_dir="$HOME/.config/caelestia"
-    local config="$config_dir/shell.json"
+    local config_dir="$HOME/.config/caelestia" config="$config_dir/shell.json"
     mkdir -p "$config_dir"
     [[ -f "$config" ]] || printf '{}\n' > "$config"
-
     jq empty "$config" >/dev/null || die "$config is not valid JSON"
     jq empty "$profile" >/dev/null || die "$profile is not valid JSON"
 
@@ -207,34 +204,23 @@ install_widgets() {
     mv "$merged" "$config"
     rm -f "$patch"
 
-    log "Widget configuration installed"
+    ok "Widget configuration installed"
     printf 'Backup of previous config: %s\n' "$backup"
 
-    if (( want_lyrics && want_visualiser )); then
-        printf 'Enabled: Desktop Lyrics + Desktop Audio Visualiser\n'
-    elif (( want_lyrics )); then
-        printf 'Enabled: Desktop Lyrics\n'
-    else
-        printf 'Enabled: Desktop Audio Visualiser\n'
-    fi
-
     if pgrep -f 'qs -c caelestia' >/dev/null 2>&1; then
-        printf '\nCaelestia is already running. If needed, restart it with:\n'
+        printf '\nCaelestia is already running. Restart if needed:\n'
         printf 'pkill -f "qs -c caelestia"; caelestia shell -d\n'
     else
-        printf '\nStarting Caelestia...\n'
         caelestia shell -d || true
     fi
-
-    printf '\nWidget-only mode did not install this repository'\''s Hyprland, Fish, SDDM, rEFInd, ASUS/G16, hibernation, refresh-rate, scripts, or systemd profiles.\n'
 }
 
 base_install() {
     is_arch_family || die "This installer currently supports Arch/CachyOS only."
 
-    log "Installing base packages"
+    log "Installing portable base packages"
     local p
-    for p in git stow rsync curl jq fish hyprland mpv playerctl brightnessctl hyprsunset sddm; do
+    for p in git stow rsync curl jq fish hyprland mpv playerctl brightnessctl hyprsunset; do
         if pacman -Si "$p" >/dev/null 2>&1; then
             sudo pacman -S --needed "$p"
         else
@@ -242,58 +228,99 @@ base_install() {
         fi
     done
 
-    # DiM Caelestia remains the daily shell. Keep it separate from archived
-    # development shell experiments.
     install_flexible_pkg dim-caelestia-shell-git || warn "Could not install dim-caelestia-shell-git."
     install_flexible_pkg caelestia-cli || warn "Could not install caelestia-cli."
 
-    log "Applying GNU Stow packages"
+    log "Applying PORTABLE Stow packages"
     local pkg
     for pkg in caelestia fish hypr mpv scripts systemd; do
-        [[ -d "$DOTFILES_DIR/$pkg" ]] || continue
-        backup_stow_conflicts "$pkg"
-        stow -d "$DOTFILES_DIR" -t "$HOME" --restow "$pkg"
+        stow_portable_package "$pkg"
     done
-
     systemctl --user daemon-reload 2>/dev/null || true
 
-    # Restore the exact captured SDDM/Frieren login theme automatically when
-    # this repository contains an SDDM snapshot.
-    if [[ -d "$DOTFILES_DIR/machine/sddm/themes/sddm-frieren-theme" || -f "$DOTFILES_DIR/machine/sddm/etc/sddm.conf" || -d "$DOTFILES_DIR/machine/sddm/etc/sddm.conf.d" ]]; then
-        "$DOTFILES_DIR/system-setup.sh" sddm
+    ok "Portable dotfiles installed"
+    printf '\nNo display manager, bootloader, GPU mode, hibernation, or refresh-rate service was changed.\n'
+}
+
+show_detected_machine() {
+    local vendor product
+    vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+    product="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+    printf '\nDetected machine\n'
+    printf '  Vendor : %s\n' "${vendor:-unknown}"
+    printf '  Product: %s\n\n' "${product:-unknown}"
+}
+
+interactive_install() {
+    local do_base=0 do_asus=0 do_g16=0 do_sddm_theme=0
+    local do_refind=0 do_refresh=0 do_hibernate=0
+    local vendor product
+
+    vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+    product="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+
+    show_detected_machine
+
+    prompt_yes_no "Install portable Hyprland/Caelestia/Fish dotfiles?" y && do_base=1
+
+    if [[ "$vendor" == *ASUS* || "$vendor" == *ASUSTeK* ]]; then
+        prompt_yes_no "ASUS laptop detected. Install generic ASUS support?" y && do_asus=1
+    fi
+    if [[ "$product" =~ GU60[35] || "$product" == *"Zephyrus G16"* ]]; then
+        prompt_yes_no "Zephyrus G16 detected. Install safe G16 extras?" y && { do_g16=1; do_asus=1; }
     fi
 
-    log "Base dotfiles installed."
+    prompt_yes_no "Install the Frieren SDDM THEME only (no autologin/DM switch)?" n && do_sddm_theme=1
+
+    printf '\nAdvanced / machine-changing options (all default to NO):\n'
+    prompt_yes_no "Configure rEFInd safely for THIS machine?" n && do_refind=1
+    prompt_yes_no "Enable the captured 120/240 Hz refresh automation if this panel is compatible?" n && do_refresh=1
+    prompt_yes_no "Configure Btrfs hibernation swap?" n && do_hibernate=1
+
+    (( do_base )) && base_install
+    (( do_asus && ! do_g16 )) && "$DOTFILES_DIR/system-setup.sh" asus
+    (( do_g16 )) && "$DOTFILES_DIR/system-setup.sh" g16
+    (( do_sddm_theme )) && "$DOTFILES_DIR/system-setup.sh" sddm-theme
+    (( do_refind )) && "$DOTFILES_DIR/system-setup.sh" refind
+    (( do_refresh )) && "$DOTFILES_DIR/system-setup.sh" refresh
+    (( do_hibernate )) && "$DOTFILES_DIR/system-setup.sh" hibernate
+
+    "$DOTFILES_DIR/system-setup.sh" status || true
 }
 
 usage() {
     cat <<'EOF'
+Huzaifah dotfiles — safe installer
+
 Usage: ./install.sh [options]
 
 No options:
-  Interactive installer. Base dotfiles are always installed first.
+  Interactive installer. Nothing machine-specific is applied silently.
 
-Options:
-  --base          Base CachyOS/Arch + Hyprland + DiM Caelestia dotfiles
-  --widgets LIST  Install only selected Caelestia desktop widgets
-  --asus          ASUS laptop support (asusctl + ROG Control Center)
-  --g16           Zephyrus G16 profile; implies --asus
-  --refind        rEFInd install/restore/customization
-  --refresh       Enable the existing 120/240 Hz AC/battery refresh service
-  --hibernate     Configure the existing Btrfs 20G hibernation swap setup
-  --all           Base + detected ASUS/G16 + rEFInd + refresh + hibernate
-  --status        Print system/dotfiles hardware status
-  --sddm          Restore the exact captured Frieren SDDM login theme/config
-  --help          Show this help
+Portable / safe:
+  --base             Install portable Hyprland/Caelestia/Fish dotfiles
+  --widgets LIST     Install selected Caelestia widgets only
+  --asus             Generic ASUS packages; never switches GPU mode
+  --g16              Safe G16 extras; implies --asus
+  --sddm-theme       Install Frieren SDDM theme only; no autologin or DM switch
+  --all              Portable base + auto-detected safe ASUS/G16 extras
 
-Examples:
-  ./install.sh --base
-  ./install.sh --widgets lyrics
-  ./install.sh --widgets visualiser
-  ./install.sh --widgets lyrics,visualiser
-  ./install.sh --asus
-  ./install.sh --g16 --refind
-  ./install.sh --all
+Explicit machine-changing actions:
+  --refind           Safely install/configure rEFInd for the current machine
+  --refresh          Enable captured refresh automation only after compatibility checks
+  --hibernate        Configure Btrfs hibernation swap
+  --sddm             Restore the exact captured SDDM config (guarded + confirmation)
+  --force-machine-profile
+                     Allow exact captured machine profile on a non-matching model
+                     (only with an explicit machine-specific action)
+
+Other:
+  --status           Print setup/hardware status
+  --help             Show this help
+
+Important:
+  --base and --all never touch SDDM configuration, boot order, rEFInd,
+  GPU mode, refresh-rate activation, or hibernation.
 EOF
 }
 
@@ -301,37 +328,37 @@ main() {
     ensure_repo "$@"
     is_arch_family || die "This installer currently supports Arch/CachyOS only."
 
-    local do_asus=0 do_g16=0 do_refind=0 do_refresh=0 do_hibernate=0 do_status=0
+    if (($# == 0)); then
+        interactive_install
+        return
+    fi
+
+    local do_base=0 do_asus=0 do_g16=0 do_sddm_theme=0 do_sddm_exact=0
+    local do_refind=0 do_refresh=0 do_hibernate=0 do_status=0 do_all=0
     local widget_spec=""
-    local explicit=0
 
     while (($#)); do
         case "$1" in
-            --base) explicit=1 ;;
+            --base) do_base=1 ;;
             --widgets)
                 [[ $# -ge 2 ]] || die "--widgets requires a value"
                 widget_spec="$2"
-                explicit=1
                 shift
                 ;;
-            --widgets=*)
-                widget_spec="${1#*=}"
-                explicit=1
+            --widgets=*) widget_spec="${1#*=}" ;;
+            --asus) do_asus=1 ;;
+            --g16) do_g16=1; do_asus=1 ;;
+            --sddm-theme) do_sddm_theme=1 ;;
+            --sddm) do_sddm_exact=1 ;;
+            --refind) do_refind=1 ;;
+            --refresh) do_refresh=1 ;;
+            --hibernate) do_hibernate=1 ;;
+            --status) do_status=1 ;;
+            --all) do_all=1 ;;
+            --force-machine-profile)
+                export DOTFILES_FORCE_MACHINE_PROFILE=1
                 ;;
-            --asus) do_asus=1; explicit=1 ;;
-            --g16) do_g16=1; do_asus=1; explicit=1 ;;
-            --refind) do_refind=1; explicit=1 ;;
-            --refresh) do_refresh=1; explicit=1 ;;
-            --hibernate) do_hibernate=1; explicit=1 ;;
-            --sddm) explicit=1; base_install; "$DOTFILES_DIR/system-setup.sh" sddm; exit 0 ;;
-            --status) do_status=1; explicit=1 ;;
-            --all)
-                do_asus=1; do_refind=1; do_refresh=1; do_hibernate=1; explicit=1
-                if grep -Eqi 'GU60[35]|Zephyrus G16' /sys/class/dmi/id/product_name 2>/dev/null; then
-                    do_g16=1
-                fi
-                ;;
-            --help|-h) usage; exit 0 ;;
+            --help|-h) usage; return ;;
             *) die "Unknown option: $1" ;;
         esac
         shift
@@ -339,35 +366,34 @@ main() {
 
     if [[ -n "$widget_spec" ]]; then
         install_widgets "$widget_spec"
-        exit 0
     fi
 
-    base_install
-
-    if (( explicit == 0 )); then
+    if (( do_all )); then
+        do_base=1
         local vendor product
         vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
         product="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
-
         if [[ "$vendor" == *ASUS* || "$vendor" == *ASUSTeK* ]]; then
-            prompt_yes_no "ASUS laptop detected ($product). Install ASUS support?" y && do_asus=1
+            do_asus=1
         fi
         if [[ "$product" =~ GU60[35] || "$product" == *"Zephyrus G16"* ]]; then
-            prompt_yes_no "Zephyrus G16-like model detected. Enable G16 extras?" y && { do_g16=1; do_asus=1; }
+            do_g16=1
+            do_asus=1
         fi
-        prompt_yes_no "Configure rEFInd from the saved profile?" n && do_refind=1
-        prompt_yes_no "Enable 120/240 Hz AC/battery refresh automation?" n && do_refresh=1
-        prompt_yes_no "Configure the 20G Btrfs hibernation swap setup?" n && do_hibernate=1
+        warn "--all is intentionally SAFE: rEFInd, exact SDDM, refresh activation, and hibernation are skipped unless separately requested."
     fi
 
-    (( do_asus )) && "$DOTFILES_DIR/system-setup.sh" asus
+    (( do_base )) && base_install
+    (( do_asus && ! do_g16 )) && "$DOTFILES_DIR/system-setup.sh" asus
     (( do_g16 )) && "$DOTFILES_DIR/system-setup.sh" g16
+    (( do_sddm_theme )) && "$DOTFILES_DIR/system-setup.sh" sddm-theme
+    (( do_sddm_exact )) && "$DOTFILES_DIR/system-setup.sh" sddm
     (( do_refind )) && "$DOTFILES_DIR/system-setup.sh" refind
     (( do_refresh )) && "$DOTFILES_DIR/system-setup.sh" refresh
     (( do_hibernate )) && "$DOTFILES_DIR/system-setup.sh" hibernate
     (( do_status )) && "$DOTFILES_DIR/system-setup.sh" status
 
-    log "Done."
+    ok "Done"
 }
 
 main "$@"

--- a/machine/refind/refind_linux.conf
+++ b/machine/refind/refind_linux.conf
@@ -1,3 +1,3 @@
 "Boot with standard options"  "root=UUID=__ROOT_UUID__ rw rootflags=subvol=/@ zswap.enabled=0 nowatchdog quiet splash i915.enable_dpcd_backlight=3"
 "Boot to single-user mode"    "root=UUID=__ROOT_UUID__ rw rootflags=subvol=/@ zswap.enabled=0 nowatchdog quiet splash i915.enable_dpcd_backlight=3 single"
-"Boot with minimal options"   "ro root=/dev/nvme0n1p5"
+"Boot with minimal options"   "ro root=UUID=__ROOT_UUID__"

--- a/system-setup.sh
+++ b/system-setup.sh
@@ -5,11 +5,14 @@ REPO_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 MACHINE_DIR="$REPO_DIR/machine"
 PKG_DIR="$MACHINE_DIR/packages"
 REFIND_BACKUP_DIR="$MACHINE_DIR/refind"
-SWAP_DIR="/swap"
-SWAPFILE="/swap/swapfile"
-SWAP_SIZE="20G"
+SDDM_BACKUP_DIR="$MACHINE_DIR/sddm"
+
+SWAP_DIR="${DOTFILES_SWAP_DIR:-/swap}"
+SWAPFILE="${DOTFILES_SWAPFILE:-$SWAP_DIR/swapfile}"
+SWAP_SIZE="${DOTFILES_SWAP_SIZE:-20G}"
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()   { printf '\033[1;32m✓\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33mWARNING:\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
 
@@ -25,6 +28,10 @@ require_arch() {
 
 prompt_yes_no() {
     local prompt="$1" default="${2:-n}" ans
+    if [[ ! -r /dev/tty ]]; then
+        [[ "$default" == "y" ]]
+        return
+    fi
     if [[ "$default" == "y" ]]; then
         read -r -p "$prompt [Y/n] " ans < /dev/tty || true
         ans="${ans:-y}"
@@ -37,7 +44,9 @@ prompt_yes_no() {
 
 install_flexible() {
     local pkg="$1"
-    if pacman -Q "$pkg" >/dev/null 2>&1; then return; fi
+    if pacman -Q "$pkg" >/dev/null 2>&1; then
+        return
+    fi
     if pacman -Si "$pkg" >/dev/null 2>&1; then
         sudo pacman -S --needed "$pkg"
         return
@@ -51,11 +60,57 @@ install_flexible() {
     fi
 }
 
+machine_value() {
+    local key="$1" file="$MACHINE_DIR/current-system.txt"
+    [[ -f "$file" ]] || return 1
+    sed -n "s/^${key}=//p" "$file" | head -1
+}
+
+current_vendor() {
+    cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true
+}
+
+current_product() {
+    cat /sys/class/dmi/id/product_name 2>/dev/null || true
+}
+
+is_g16() {
+    local product
+    product="$(current_product)"
+    [[ "$product" =~ GU60[35] || "$product" == *"Zephyrus G16"* ]]
+}
+
+machine_profile_matches() {
+    local saved_vendor saved_product vendor product
+    saved_vendor="$(machine_value dmi_vendor 2>/dev/null || true)"
+    saved_product="$(machine_value dmi_product 2>/dev/null || true)"
+    vendor="$(current_vendor)"
+    product="$(current_product)"
+
+    [[ -n "$saved_vendor" && -n "$saved_product" ]] || return 1
+    [[ "$saved_vendor" == "$vendor" && "$saved_product" == "$product" ]]
+}
+
+allow_exact_machine_profile() {
+    if machine_profile_matches; then
+        return 0
+    fi
+    if [[ "${DOTFILES_FORCE_MACHINE_PROFILE:-0}" == "1" ]]; then
+        warn "FORCING a captured machine profile onto a non-matching machine."
+        return 0
+    fi
+
+    warn "Captured profile: $(machine_value dmi_vendor 2>/dev/null || echo unknown) / $(machine_value dmi_product 2>/dev/null || echo unknown)"
+    warn "Current machine : $(current_vendor) / $(current_product)"
+    return 1
+}
+
 secure_boot_enabled() {
     if command -v mokutil >/dev/null 2>&1; then
         mokutil --sb-state 2>/dev/null | grep -qi 'enabled'
         return
     fi
+
     [[ -d /sys/firmware/efi/efivars ]] || return 1
     local var
     var="$(find /sys/firmware/efi/efivars -maxdepth 1 -name 'SecureBoot-*' -print -quit 2>/dev/null || true)"
@@ -63,34 +118,80 @@ secure_boot_enabled() {
     od -An -t u1 -j 4 -N 1 "$var" 2>/dev/null | grep -Eq '[[:space:]]1[[:space:]]*$'
 }
 
+is_vfat_mount() {
+    local p="$1" fs
+    mountpoint -q "$p" 2>/dev/null || return 1
+    fs="$(findmnt -n -o FSTYPE --target "$p" 2>/dev/null || true)"
+    [[ "$fs" == "vfat" || "$fs" == "fat" || "$fs" == "msdos" ]]
+}
+
 find_esp() {
     local p
-    for p in /boot /boot/efi /efi; do
-        if mountpoint -q "$p" 2>/dev/null && find "$p/EFI" -maxdepth 2 -iname 'refind_x64.efi' -print -quit 2>/dev/null | grep -q .; then
+
+    # Prefer the conventional dedicated ESP paths first. This avoids choosing
+    # /boot when /boot/efi is the actual FAT ESP.
+    for p in /boot/efi /efi /boot; do
+        if is_vfat_mount "$p"; then
             printf '%s\n' "$p"
             return 0
         fi
     done
-    for p in /boot /boot/efi /efi; do
-        mountpoint -q "$p" 2>/dev/null && { printf '%s\n' "$p"; return 0; }
-    done
+
+    # Fallback: any mounted FAT filesystem with an EFI directory.
+    while IFS= read -r p; do
+        [[ -d "$p/EFI" ]] || continue
+        printf '%s\n' "$p"
+        return 0
+    done < <(findmnt -rn -t vfat,fat,msdos -o TARGET 2>/dev/null || true)
+
     return 1
 }
 
 find_refind_conf() {
     local esp="${1:-}" p
+
+    if [[ -n "$esp" ]]; then
+        for p in \
+            "$esp/EFI/refind/refind.conf" \
+            "$esp/EFI/REFIND/refind.conf"; do
+            [[ -f "$p" ]] && { printf '%s\n' "$p"; return 0; }
+        done
+    fi
+
     for p in \
-        "$esp/EFI/refind/refind.conf" \
-        /boot/EFI/refind/refind.conf \
         /boot/efi/EFI/refind/refind.conf \
-        /efi/EFI/refind/refind.conf; do
+        /efi/EFI/refind/refind.conf \
+        /boot/EFI/refind/refind.conf; do
         [[ -f "$p" ]] && { printf '%s\n' "$p"; return 0; }
     done
+
+    # Last-resort search after refind-install. Keep it shallow and scoped.
+    local root found
+    for root in /boot/efi /efi /boot; do
+        [[ -d "$root" ]] || continue
+        found="$(sudo find "$root" -maxdepth 4 -type f -iname refind.conf -path '*/EFI/*' -print -quit 2>/dev/null || true)"
+        if [[ -n "$found" ]]; then
+            printf '%s\n' "$found"
+            return 0
+        fi
+    done
+
     return 1
 }
 
 current_root_uuid() {
-    findmnt -no UUID /
+    findmnt -no UUID / 2>/dev/null || true
+}
+
+current_boot_order() {
+    efibootmgr 2>/dev/null | sed -n 's/^BootOrder:[[:space:]]*//p' | tr -d ' ' | head -1
+}
+
+restore_boot_order() {
+    local order="$1"
+    [[ -n "$order" ]] || return 0
+    log "Restoring previous UEFI BootOrder: $order"
+    sudo efibootmgr -o "$order" >/dev/null
 }
 
 sync_dir() {
@@ -123,8 +224,6 @@ capture_dotfiles() {
     sync_dir "$HOME/.config/systemd/user" "$REPO_DIR/systemd/.config/systemd/user"
     sync_dir "$HOME/.local/bin" "$REPO_DIR/scripts/.local/bin"
 
-    # Preserve the archived custom-shell development state as a manifest, not
-    # as a nested Git repository inside dotfiles.
     local shell_repo="$HOME/.config/quickshell/huzaifah-shell-dev"
     if [[ -d "$shell_repo/.git" ]]; then
         {
@@ -136,12 +235,14 @@ capture_dotfiles() {
     fi
 }
 
-
 capture_widget_profile() {
     local src="$HOME/.config/caelestia/shell.json"
     local dst="$REPO_DIR/widgets/caelestia-widget-profile.json"
 
-    [[ -f "$src" ]] || { warn "No Caelestia shell.json; skipping widget profile capture."; return 0; }
+    [[ -f "$src" ]] || {
+        warn "No Caelestia shell.json; skipping widget profile capture."
+        return 0
+    }
 
     mkdir -p "$REPO_DIR/widgets"
 
@@ -182,7 +283,7 @@ capture_widget_profile() {
         )
     }' "$src" > "$dst"
 
-    log "Saved portable Lyrics/Visualiser widget profile."
+    ok "Saved portable Lyrics/Visualiser widget profile"
 }
 
 capture_packages() {
@@ -192,31 +293,46 @@ capture_packages() {
     pacman -Qqen | grep -Evi "$excludes" | sort -u > "$PKG_DIR/pacman.txt"
     pacman -Qqem | grep -Evi "$excludes" | sort -u > "$PKG_DIR/aur.txt"
 
-    log "Saved package lists (GPU/NVIDIA/CUDA and Secure-Boot tooling intentionally excluded)."
+    ok "Saved package lists (GPU/NVIDIA/CUDA and Secure-Boot tooling excluded)"
 }
 
 capture_refind() {
     mkdir -p "$REFIND_BACKUP_DIR"
+
     local esp conf root_uuid
     esp="$(find_esp || true)"
-    [[ -n "$esp" ]] || { warn "No mounted ESP found; skipping rEFInd capture."; return 0; }
+    [[ -n "$esp" ]] || {
+        warn "No mounted ESP found; skipping rEFInd capture."
+        return 0
+    }
 
     conf="$(find_refind_conf "$esp" || true)"
-    [[ -n "$conf" ]] || { warn "No rEFInd config found; skipping rEFInd capture."; return 0; }
+    [[ -n "$conf" ]] || {
+        warn "No rEFInd config found; skipping rEFInd capture."
+        return 0
+    }
 
     root_uuid="$(current_root_uuid)"
     sudo cat "$conf" > "$REFIND_BACKUP_DIR/refind.conf"
-    if [[ -n "$root_uuid" ]]; then
-        sed -Ei "s#root=UUID=[A-Fa-f0-9-]+#root=UUID=__ROOT_UUID__#g" "$REFIND_BACKUP_DIR/refind.conf"
-    fi
 
-    if [[ -f "$esp/refind_linux.conf" ]]; then
-        sudo cat "$esp/refind_linux.conf" > "$REFIND_BACKUP_DIR/refind_linux.conf"
-        if [[ -n "$root_uuid" ]]; then
-            sed -Ei "s#root=UUID=[A-Fa-f0-9-]+#root=UUID=__ROOT_UUID__#g" "$REFIND_BACKUP_DIR/refind_linux.conf"
-        fi
+    # Sanitize root identifiers. The snapshot remains a backup; the portable
+    # installer does NOT deploy this complete config to another machine.
+    sed -Ei \
+        -e 's#root=UUID=[A-Fa-f0-9-]+#root=UUID=__ROOT_UUID__#g' \
+        -e 's#root=/dev/[^ " ]+#root=UUID=__ROOT_UUID__#g' \
+        "$REFIND_BACKUP_DIR/refind.conf"
+
+    local linux_conf=""
+    for linux_conf in "$esp/refind_linux.conf" /boot/refind_linux.conf; do
+        [[ -f "$linux_conf" ]] || continue
+        sudo cat "$linux_conf" > "$REFIND_BACKUP_DIR/refind_linux.conf"
+        sed -Ei \
+            -e 's#root=UUID=[A-Fa-f0-9-]+#root=UUID=__ROOT_UUID__#g' \
+            -e 's#root=/dev/[^ " ]+#root=UUID=__ROOT_UUID__#g' \
+            "$REFIND_BACKUP_DIR/refind_linux.conf"
         chmod 0644 "$REFIND_BACKUP_DIR/refind_linux.conf"
-    fi
+        break
+    done
 
     local theme_src
     theme_src="$(dirname "$conf")/themes/rEFInd-minimal"
@@ -226,8 +342,16 @@ capture_refind() {
         sudo cp -a "$theme_src" "$REFIND_BACKUP_DIR/themes/rEFInd-minimal"
         sudo chown -R "$USER":"$(id -gn)" "$REFIND_BACKUP_DIR/themes"
     fi
+
+    {
+        printf 'captured_at=%s\n' "$(date --iso-8601=seconds)"
+        printf 'esp=%s\n' "$esp"
+        printf 'config=%s\n' "$conf"
+        printf 'root_uuid=%s\n' "$root_uuid"
+    } > "$REFIND_BACKUP_DIR/manifest.txt"
+
     chmod 0644 "$REFIND_BACKUP_DIR/refind.conf"
-    log "Saved sanitized rEFInd config and theme assets."
+    ok "Saved sanitized rEFInd backup and theme assets"
 }
 
 capture_system_info() {
@@ -238,18 +362,17 @@ capture_system_info() {
         printf 'kernel=%s\n' "$(uname -r)"
         printf 'root_fs=%s\n' "$(findmnt -no FSTYPE /)"
         printf 'root_uuid=%s\n' "$(current_root_uuid)"
-        printf 'dmi_vendor=%s\n' "$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
-        printf 'dmi_product=%s\n' "$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+        printf 'dmi_vendor=%s\n' "$(current_vendor)"
+        printf 'dmi_product=%s\n' "$(current_product)"
         printf 'swap=%s\n' "$(swapon --show --noheadings --raw 2>/dev/null | tr '\n' ';' || true)"
     } > "$MACHINE_DIR/current-system.txt"
 }
 
-
 capture_sddm() {
-    local dst="$MACHINE_DIR/sddm"
+    local dst="$SDDM_BACKUP_DIR"
     local theme_src="/usr/share/sddm/themes/sddm-frieren-theme"
 
-    log "Capturing exact SDDM/Frieren login theme and configuration"
+    log "Capturing exact SDDM/Frieren theme and configuration"
     rm -rf "$dst"
     mkdir -p "$dst/themes" "$dst/etc"
 
@@ -274,74 +397,13 @@ capture_sddm() {
     {
         printf 'captured_at=%s\n' "$(date --iso-8601=seconds)"
         printf 'theme_path=%s\n' "$theme_src"
-        printf 'display_manager=%s\n' "$(systemctl status display-manager.service --no-pager 2>/dev/null | sed -n 's/.*Loaded: loaded (\([^;]*\).*/\1/p' | head -1 || true)"
+        printf 'dmi_vendor=%s\n' "$(current_vendor)"
+        printf 'dmi_product=%s\n' "$(current_product)"
         printf 'sddm_version=%s\n' "$(sddm --version 2>/dev/null | head -1 || true)"
     } > "$dst/manifest.txt"
 
-    log "Exact SDDM snapshot saved under machine/sddm/"
+    ok "Exact SDDM snapshot saved under machine/sddm/"
 }
-
-restore_sddm() {
-    require_arch
-
-    local src="$MACHINE_DIR/sddm"
-    local theme_src="$src/themes/sddm-frieren-theme"
-    local theme_dst="/usr/share/sddm/themes/sddm-frieren-theme"
-    local stamp backup dm_target
-
-    if [[ ! -d "$theme_src" && ! -f "$src/etc/sddm.conf" && ! -d "$src/etc/sddm.conf.d" ]]; then
-        warn "No captured SDDM snapshot exists in machine/sddm; skipping."
-        return 0
-    fi
-
-    sudo pacman -S --needed sddm rsync
-    sudo -v
-
-    stamp="$(date +%Y%m%d-%H%M%S)"
-    backup="/var/backups/huzaifah-dotfiles/sddm/$stamp"
-    sudo mkdir -p "$backup"
-
-    if sudo test -d "$theme_dst"; then
-        sudo cp -a "$theme_dst" "$backup/sddm-frieren-theme"
-    fi
-    if sudo test -f /etc/sddm.conf; then
-        sudo cp -a /etc/sddm.conf "$backup/sddm.conf"
-    fi
-    if sudo test -d /etc/sddm.conf.d; then
-        sudo cp -a /etc/sddm.conf.d "$backup/sddm.conf.d"
-    fi
-
-    if [[ -d "$theme_src" ]]; then
-        sudo mkdir -p /usr/share/sddm/themes
-        sudo rm -rf "$theme_dst"
-        sudo cp -a "$theme_src" "$theme_dst"
-        sudo chown -R root:root "$theme_dst"
-    fi
-
-    if [[ -f "$src/etc/sddm.conf" ]]; then
-        sudo install -o root -g root -m 0644 "$src/etc/sddm.conf" /etc/sddm.conf
-    fi
-
-    if [[ -d "$src/etc/sddm.conf.d" ]]; then
-        sudo mkdir -p /etc/sddm.conf.d
-        sudo rsync -a --delete "$src/etc/sddm.conf.d/" /etc/sddm.conf.d/
-        sudo chown -R root:root /etc/sddm.conf.d
-    fi
-
-    # On a fresh install, enable SDDM if no other display manager currently
-    # owns display-manager.service. Never replace another configured DM.
-    dm_target="$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null || true)"
-    if [[ -z "$dm_target" || "$dm_target" == *"/sddm.service" ]]; then
-        sudo systemctl enable sddm.service
-    else
-        warn "Another display manager is configured: $dm_target"
-        warn "Frieren SDDM files were restored, but SDDM was not enabled automatically."
-    fi
-
-    log "Restored the exact captured Frieren SDDM login theme/configuration."
-    log "Previous SDDM files were backed up to $backup"
-}
-
 
 capture() {
     require_arch
@@ -359,12 +421,14 @@ capture() {
 
 restore_packages() {
     require_arch
-    local f
+
+    local -a pkgs=()
     if [[ -f "$PKG_DIR/pacman.txt" ]]; then
         mapfile -t pkgs < <(grep -Ev '^[[:space:]]*(#|$)' "$PKG_DIR/pacman.txt")
         ((${#pkgs[@]})) && sudo pacman -S --needed "${pkgs[@]}"
     fi
 
+    pkgs=()
     if [[ -f "$PKG_DIR/aur.txt" ]]; then
         command -v paru >/dev/null 2>&1 || die "paru is required to restore AUR packages."
         mapfile -t pkgs < <(grep -Ev '^[[:space:]]*(#|$)' "$PKG_DIR/aur.txt")
@@ -376,9 +440,10 @@ restore_packages() {
 
 setup_asus() {
     require_arch
+
     local vendor product
-    vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
-    product="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+    vendor="$(current_vendor)"
+    product="$(current_product)"
 
     if [[ "$vendor" != *ASUS* && "$vendor" != *ASUSTeK* ]]; then
         warn "This does not appear to be an ASUS laptop ($vendor / $product)."
@@ -401,55 +466,332 @@ setup_asus() {
 
     sudo udevadm trigger 2>/dev/null || true
 
-    log "ASUS setup complete."
-    asusctl --version 2>/dev/null || true
-    printf '\nUseful commands:\n'
-    printf '  asusctl --help\n'
-    printf '  asusctl profile -n        # cycle supported performance profiles\n'
-    printf '  rog-control-center        # GUI\n'
+    ok "ASUS setup complete"
     printf '\nNo GPU mode was changed automatically.\n'
 }
 
 setup_g16() {
     require_arch
-    local product
-    product="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
 
-    if [[ ! "$product" =~ GU60[35] && "$product" != *"Zephyrus G16"* ]]; then
+    local product
+    product="$(current_product)"
+
+    if ! is_g16; then
         warn "DMI product '$product' was not recognized as a GU603/GU605/Zephyrus G16."
-        prompt_yes_no "Apply the G16 profile anyway?" n || return 0
+        prompt_yes_no "Install G16 packages anyway?" n || return 0
     fi
 
     setup_asus
 
     log "Zephyrus G16 extras"
-    printf 'This profile keeps your existing Hyprland 1.25 scale and 120/240 Hz automation.\n'
-    printf 'It does NOT install or modify NVIDIA/CUDA drivers.\n\n'
+    printf 'No NVIDIA/CUDA driver, GPU mode, display timing, bootloader, or hibernation setting will be changed here.\n'
 
-    if prompt_yes_no "Install optional supergfxctl GPU-switching tools?" n; then
+    if prompt_yes_no "Install optional supergfxctl GPU-switching tools (without switching modes)?" n; then
         install_flexible supergfxctl
         if systemctl list-unit-files supergfxd.service >/dev/null 2>&1; then
             sudo systemctl enable --now supergfxd.service
         fi
-        printf '\nGPU commands (run manually only after checking current state):\n'
-        printf '  supergfxctl --help\n'
-        printf '  supergfxctl --mode Hybrid\n'
-        printf '  supergfxctl --mode Integrated\n'
-        printf '\nThe installer will never switch GPU mode automatically.\n'
     fi
 
-    if [[ -f "$HOME/.config/systemd/user/auto-refresh-rate.service" ]]; then
-        if prompt_yes_no "Enable the existing 120/240 Hz AC/battery refresh service?" y; then
-            enable_refresh
+    ok "G16 safe extras complete"
+    printf 'Refresh-rate automation remains opt-in: ./install.sh --refresh\n'
+}
+
+install_sddm_theme_only() {
+    require_arch
+
+    local theme_src="$SDDM_BACKUP_DIR/themes/sddm-frieren-theme"
+    local theme_dst="/usr/share/sddm/themes/sddm-frieren-theme"
+    [[ -d "$theme_src" ]] || die "Captured Frieren theme is missing: $theme_src"
+
+    sudo pacman -S --needed sddm rsync
+    sudo -v
+
+    local stamp backup
+    stamp="$(date +%Y%m%d-%H%M%S)"
+    backup="/var/backups/huzaifah-dotfiles/sddm-theme/$stamp"
+    sudo mkdir -p "$backup"
+
+    if sudo test -d "$theme_dst"; then
+        sudo cp -a "$theme_dst" "$backup/sddm-frieren-theme"
+    fi
+
+    sudo rm -rf "$theme_dst"
+    sudo cp -a "$theme_src" "$theme_dst"
+    sudo chown -R root:root "$theme_dst"
+
+    # Theme-only drop-in. No autologin settings and no display-manager enable.
+    sudo mkdir -p /etc/sddm.conf.d
+    if sudo test -f /etc/sddm.conf.d/90-huzaifah-theme.conf; then
+        sudo cp -a /etc/sddm.conf.d/90-huzaifah-theme.conf "$backup/90-huzaifah-theme.conf"
+    fi
+    printf '[Theme]\nCurrent=sddm-frieren-theme\n' |
+        sudo tee /etc/sddm.conf.d/90-huzaifah-theme.conf >/dev/null
+
+    ok "Frieren SDDM theme installed"
+    printf 'SDDM was NOT enabled, autologin was NOT configured, and another display manager was NOT replaced.\n'
+    printf 'Backup: %s\n' "$backup"
+}
+
+restore_sddm_exact() {
+    require_arch
+
+    allow_exact_machine_profile || die "Refusing exact SDDM restore on a different machine. Use --force-machine-profile only if you understand the risk."
+
+    local src="$SDDM_BACKUP_DIR"
+    local theme_src="$src/themes/sddm-frieren-theme"
+    local theme_dst="/usr/share/sddm/themes/sddm-frieren-theme"
+
+    if [[ ! -d "$theme_src" && ! -f "$src/etc/sddm.conf" && ! -d "$src/etc/sddm.conf.d" ]]; then
+        die "No captured SDDM snapshot exists in machine/sddm."
+    fi
+
+    warn "EXACT SDDM restore can overwrite /etc/sddm.conf and /etc/sddm.conf.d."
+    prompt_yes_no "Continue with exact captured SDDM configuration?" n || {
+        log "Exact SDDM restore cancelled."
+        return 0
+    }
+
+    sudo pacman -S --needed sddm rsync
+    sudo -v
+
+    local stamp backup dm_target
+    stamp="$(date +%Y%m%d-%H%M%S)"
+    backup="/var/backups/huzaifah-dotfiles/sddm-exact/$stamp"
+    sudo mkdir -p "$backup"
+
+    sudo test -d "$theme_dst" && sudo cp -a "$theme_dst" "$backup/sddm-frieren-theme"
+    sudo test -f /etc/sddm.conf && sudo cp -a /etc/sddm.conf "$backup/sddm.conf"
+    sudo test -d /etc/sddm.conf.d && sudo cp -a /etc/sddm.conf.d "$backup/sddm.conf.d"
+
+    if [[ -d "$theme_src" ]]; then
+        sudo rm -rf "$theme_dst"
+        sudo cp -a "$theme_src" "$theme_dst"
+        sudo chown -R root:root "$theme_dst"
+    fi
+
+    if [[ -f "$src/etc/sddm.conf" ]]; then
+        sudo install -o root -g root -m 0644 "$src/etc/sddm.conf" /etc/sddm.conf
+    fi
+
+    if [[ -d "$src/etc/sddm.conf.d" ]]; then
+        sudo mkdir -p /etc/sddm.conf.d
+        sudo rsync -a --delete "$src/etc/sddm.conf.d/" /etc/sddm.conf.d/
+        sudo chown -R root:root /etc/sddm.conf.d
+    fi
+
+    dm_target="$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null || true)"
+    if [[ "$dm_target" == *"/sddm.service" ]]; then
+        ok "SDDM is already the configured display manager"
+    elif [[ -n "$dm_target" ]]; then
+        warn "Another display manager is configured: $dm_target"
+        warn "It was NOT replaced."
+    elif prompt_yes_no "No display manager is enabled. Enable SDDM?" n; then
+        sudo systemctl enable sddm.service
+    fi
+
+    ok "Exact captured SDDM files restored"
+    printf 'Backup: %s\n' "$backup"
+}
+
+generate_refind_linux_conf() {
+    local esp="$1"
+
+    if command -v mkrlconf >/dev/null 2>&1 && compgen -G '/boot/vmlinuz-*' >/dev/null; then
+        log "Generating machine-specific refind_linux.conf with mkrlconf"
+        sudo mkrlconf || warn "mkrlconf failed; rEFInd can still auto-detect kernels/UKIs."
+    else
+        warn "mkrlconf or a conventional /boot/vmlinuz-* kernel was not found; leaving kernel options to the installed boot setup."
+    fi
+
+    # Apply the known G16 Intel backlight parameter only on a detected G16.
+    # Never copy a hard-coded root device from the captured machine.
+    local linux_conf=""
+    for linux_conf in /boot/refind_linux.conf "$esp/refind_linux.conf"; do
+        [[ -f "$linux_conf" ]] || continue
+        if is_g16 && ! sudo grep -q 'i915.enable_dpcd_backlight=3' "$linux_conf"; then
+            local tmp
+            tmp="$(mktemp)"
+            sudo cat "$linux_conf" > "$tmp"
+            sed -E 's/"[[:space:]]*$/ i915.enable_dpcd_backlight=3"/' "$tmp" > "$tmp.new"
+            sudo install -m 0644 "$tmp.new" "$linux_conf"
+            rm -f "$tmp" "$tmp.new"
+            log "Added G16 Intel backlight kernel parameter to $linux_conf"
+        fi
+        return 0
+    done
+
+    return 0
+}
+
+apply_refind_theme() {
+    local conf="$1" refind_dir
+    refind_dir="$(dirname "$conf")"
+
+    local theme_src="$REFIND_BACKUP_DIR/themes/rEFInd-minimal"
+    local theme_dst="$refind_dir/themes/rEFInd-minimal"
+    [[ -f "$theme_src/theme.conf" ]] || {
+        warn "Saved rEFInd-minimal theme not found; keeping the default rEFInd appearance."
+        return 0
+    }
+
+    sudo mkdir -p "$refind_dir/themes"
+    sudo rm -rf "$theme_dst"
+    sudo cp -a "$theme_src" "$theme_dst"
+    sudo chown -R root:root "$theme_dst" 2>/dev/null || true
+
+    if ! sudo grep -Eq '^[[:space:]]*include[[:space:]]+themes/rEFInd-minimal/theme\.conf([[:space:]]|$)' "$conf"; then
+        printf '\n# Huzaifah portable theme (no machine-specific boot entries)\ninclude themes/rEFInd-minimal/theme.conf\n' |
+            sudo tee -a "$conf" >/dev/null
+    fi
+
+    ok "Applied rEFInd-minimal theme without replacing the machine's boot entries"
+}
+
+setup_refind() {
+    require_arch
+
+    [[ -d /sys/firmware/efi ]] || die "This system was not booted in UEFI mode."
+    secure_boot_enabled && die "Secure Boot is enabled. Signing rEFInd is intentionally outside this installer."
+
+    sudo pacman -S --needed refind efibootmgr
+    sudo -v
+
+    local esp conf old_order installed_now=0
+    old_order="$(current_boot_order || true)"
+    esp="$(find_esp || true)"
+    [[ -n "$esp" ]] || die "Could not detect a mounted FAT ESP at /boot/efi, /efi, or /boot."
+
+    conf="$(find_refind_conf "$esp" || true)"
+    if [[ -z "$conf" ]]; then
+        prompt_yes_no "rEFInd is not installed. Run refind-install on the detected ESP ($esp)?" y || return 0
+
+        log "Installing rEFInd"
+        if ! sudo refind-install; then
+            restore_boot_order "$old_order" || true
+            die "refind-install failed."
+        fi
+        installed_now=1
+
+        # refind-install may have selected a more specific mount such as
+        # /boot/efi. Re-detect instead of trusting the pre-install guess.
+        esp="$(find_esp || true)"
+        conf="$(find_refind_conf "$esp" || true)"
+
+        if [[ -z "$conf" ]]; then
+            restore_boot_order "$old_order" || true
+            die "rEFInd reported success, but refind.conf still could not be located. Previous BootOrder was restored."
         fi
     fi
+
+    local stamp
+    stamp="$(date +%Y%m%d-%H%M%S)"
+    sudo cp -a "$conf" "$conf.pre-huzaifah-$stamp"
+
+    apply_refind_theme "$conf"
+    generate_refind_linux_conf "$esp"
+
+    if (( installed_now )); then
+        if prompt_yes_no "Make rEFInd the default/first UEFI boot manager?" n; then
+            log "Keeping the BootOrder created by refind-install."
+        else
+            restore_boot_order "$old_order"
+            ok "Previous default boot order preserved"
+        fi
+    fi
+
+    ok "rEFInd configured safely"
+    printf 'Config: %s\n' "$conf"
+    printf 'ESP:    %s\n' "$esp"
+    printf 'Backup: %s.pre-huzaifah-%s\n' "$conf" "$stamp"
+    printf '\nThe captured full refind.conf and captured root-device lines were NOT copied to this machine.\n'
+}
+
+refresh_compatible() {
+    is_g16 || {
+        warn "The saved refresh script is G16-specific."
+        return 1
+    }
+
+    command -v hyprctl >/dev/null 2>&1 || {
+        warn "hyprctl is not available."
+        return 1
+    }
+    command -v jq >/dev/null 2>&1 || {
+        warn "jq is not available."
+        return 1
+    }
+
+    local monitors
+    monitors="$(hyprctl -j monitors 2>/dev/null || true)"
+    [[ -n "$monitors" ]] || {
+        warn "No active Hyprland IPC session was found. Log into Hyprland first, then run --refresh."
+        return 1
+    }
+
+    jq -e '
+        any(.[ ];
+            .name == "eDP-1"
+            and .width == 2560
+            and .height == 1600
+        )
+    ' <<< "$monitors" >/dev/null || {
+        warn "Expected G16 internal panel eDP-1 at 2560x1600 was not detected."
+        return 1
+    }
+
+    return 0
+}
+
+enable_refresh() {
+    require_arch
+
+    local unit="$HOME/.config/systemd/user/auto-refresh-rate.service"
+    local script="$HOME/.local/bin/auto-refresh-rate"
+
+    [[ -f "$unit" ]] || die "auto-refresh-rate.service is missing. Install the portable dotfiles first."
+    [[ -x "$script" || -f "$script" ]] || die "auto-refresh-rate script is missing."
+
+    if ! refresh_compatible; then
+        if [[ "${DOTFILES_FORCE_MACHINE_PROFILE:-0}" != "1" ]]; then
+            die "Refresh automation was NOT enabled because compatibility checks failed."
+        fi
+        warn "Forcing refresh automation despite failed compatibility checks."
+    fi
+
+    systemctl --user daemon-reload
+    systemctl --user enable --now auto-refresh-rate.service
+    ok "Enabled G16 120/240 Hz AC/battery refresh automation"
+}
+
+bytes_for_size() {
+    local size="$1"
+    numfmt --from=iec "$size" 2>/dev/null || return 1
 }
 
 setup_hibernate() {
     require_arch
+
     [[ "$(findmnt -no FSTYPE /)" == "btrfs" ]] || die "Hibernate setup expects a Btrfs root."
     sudo -v
     sudo pacman -S --needed btrfs-progs
+
+    local required free_bytes
+    required="$(bytes_for_size "$SWAP_SIZE" 2>/dev/null || echo 0)"
+    free_bytes="$(df -B1 --output=avail / | tail -1 | tr -d ' ')"
+
+    if [[ ! -f "$SWAPFILE" && "$required" -gt 0 && "$free_bytes" -lt "$required" ]]; then
+        die "Not enough free space for a $SWAP_SIZE swapfile."
+    fi
+
+    local ram_bytes
+    ram_bytes="$(awk '/MemTotal:/ {print $2 * 1024}' /proc/meminfo)"
+    if [[ "$required" -gt 0 ]] && awk -v swap="$required" -v ram="$ram_bytes" 'BEGIN { exit !(swap < ram) }'; then
+        warn "Requested swap size ($SWAP_SIZE) is smaller than installed RAM. Hibernation may fail for large memory images."
+    fi
+
+    warn "This creates/edits swap storage and /etc/fstab. It does NOT change your bootloader kernel resume parameters."
+    prompt_yes_no "Continue with Btrfs hibernation storage setup?" n || return 0
 
     if [[ ! -d "$SWAP_DIR" ]]; then
         sudo btrfs subvolume create "$SWAP_DIR"
@@ -465,117 +807,51 @@ setup_hibernate() {
     local fstab_line="$SWAPFILE none swap defaults,pri=10 0 0"
     grep -Fqx "$fstab_line" /etc/fstab || printf '%s\n' "$fstab_line" | sudo tee -a /etc/fstab >/dev/null
 
-    printf '%s\n' 'w /sys/power/image_size - - - - 0' | sudo tee /etc/tmpfiles.d/hibernation-image-size.conf >/dev/null
+    printf '%s\n' 'w /sys/power/image_size - - - - 0' |
+        sudo tee /etc/tmpfiles.d/hibernation-image-size.conf >/dev/null
     printf '0' | sudo tee /sys/power/image_size >/dev/null
 
-    log "Btrfs swapfile resume offset:"
-    sudo btrfs inspect-internal map-swapfile -r "$SWAPFILE"
+    local offset
+    offset="$(sudo btrfs inspect-internal map-swapfile -r "$SWAPFILE")"
 
-    if grep -Eq '^HOOKS=.*\bsystemd\b' /etc/mkinitcpio.conf 2>/dev/null; then
-        log "mkinitcpio systemd hook detected."
-    else
-        warn "mkinitcpio 'systemd' hook was not detected; verify your hibernation initramfs configuration."
-    fi
-
-    log "Hibernate storage configured. The script will not hibernate the machine automatically."
-}
-
-setup_refind() {
-    require_arch
-    secure_boot_enabled && die "Secure Boot is enabled. Secure-Boot signing is intentionally outside this installer."
-
-    sudo pacman -S --needed refind efibootmgr
-
-    local esp conf refind_dir root_uuid saved
-    esp="$(find_esp || true)"
-    [[ -n "$esp" ]] || die "Could not detect a mounted ESP at /boot, /boot/efi, or /efi."
-
-    conf="$(find_refind_conf "$esp" || true)"
-    if [[ -z "$conf" ]]; then
-        prompt_yes_no "rEFInd is not installed on the detected ESP. Run refind-install?" y || return 0
-        sudo refind-install
-        conf="$(find_refind_conf "$esp" || true)"
-        [[ -n "$conf" ]] || die "rEFInd installed but refind.conf could not be found."
-    fi
-
-    refind_dir="$(dirname "$conf")"
-    sudo cp -a "$conf" "$conf.fresh-backup-$(date +%Y%m%d-%H%M%S)"
-
-    saved="$REFIND_BACKUP_DIR/refind.conf"
-    root_uuid="$(current_root_uuid)"
-
-    if [[ -f "$saved" ]]; then
-        local tmp
-        tmp="$(mktemp)"
-        sed "s/__ROOT_UUID__/$root_uuid/g" "$saved" > "$tmp"
-        # Compatibility with an older captured config that still had a UUID.
-        sed -Ei "s#root=UUID=[A-Fa-f0-9-]+#root=UUID=$root_uuid#g" "$tmp"
-        sudo install -m 0644 "$tmp" "$conf"
-        rm -f "$tmp"
-    fi
-
-    if [[ -d "$REFIND_BACKUP_DIR/themes/rEFInd-minimal" ]]; then
-        sudo mkdir -p "$refind_dir/themes"
-        sudo rm -rf "$refind_dir/themes/rEFInd-minimal"
-        sudo cp -a "$REFIND_BACKUP_DIR/themes/rEFInd-minimal" "$refind_dir/themes/rEFInd-minimal"
-    fi
-
-    # Ensure Linux is launched in graphics mode without duplicating active lines.
-    if sudo grep -Eq '^[[:space:]]*use_graphics_for\b.*\blinux\b' "$conf"; then
-        :
-    else
-        printf '\nuse_graphics_for + linux\n' | sudo tee -a "$conf" >/dev/null
-    fi
-
-    if [[ -f "$REFIND_BACKUP_DIR/refind_linux.conf" ]]; then
-        local linux_tmp
-        linux_tmp="$(mktemp)"
-        sed "s/__ROOT_UUID__/$root_uuid/g" "$REFIND_BACKUP_DIR/refind_linux.conf" > "$linux_tmp"
-        sudo install -m 0600 "$linux_tmp" "$esp/refind_linux.conf"
-        rm -f "$linux_tmp"
-    fi
-
-    if command -v mkrlconf >/dev/null 2>&1 && [[ ! -f "$esp/refind_linux.conf" && ! -f /boot/refind_linux.conf ]]; then
-        if prompt_yes_no "Generate a machine-specific refind_linux.conf with mkrlconf?" n; then
-            sudo mkrlconf
-        fi
-    fi
-
-    log "rEFInd profile restored."
-    printf 'Config: %s\n' "$conf"
-    printf 'ESP:    %s\n' "$esp"
-}
-
-enable_refresh() {
-    local unit="$HOME/.config/systemd/user/auto-refresh-rate.service"
-    [[ -f "$unit" ]] || die "auto-refresh-rate.service is missing. Run ./install.sh first."
-    systemctl --user daemon-reload
-    systemctl --user enable --now auto-refresh-rate.service
-    log "Enabled 120/240 Hz AC/battery refresh automation."
+    ok "Btrfs hibernation storage configured"
+    printf 'Swapfile:      %s\n' "$SWAPFILE"
+    printf 'Resume offset: %s\n' "$offset"
+    warn "Verify your initramfs and kernel resume configuration before relying on hibernation."
 }
 
 status_report() {
-    printf 'OS:             '
+    printf 'OS:               '
     grep '^PRETTY_NAME=' /etc/os-release 2>/dev/null | cut -d= -f2- | tr -d '"'
-    printf 'Kernel:         %s\n' "$(uname -r)"
-    printf 'Root FS:        %s\n' "$(findmnt -no FSTYPE / 2>/dev/null || true)"
-    printf 'DMI vendor:     %s\n' "$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
-    printf 'DMI product:    %s\n' "$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+    printf 'Kernel:           %s\n' "$(uname -r)"
+    printf 'Root FS:          %s\n' "$(findmnt -no FSTYPE / 2>/dev/null || true)"
+    printf 'DMI vendor:       %s\n' "$(current_vendor)"
+    printf 'DMI product:      %s\n' "$(current_product)"
+    printf 'Captured profile: %s\n' "$(machine_value dmi_product 2>/dev/null || echo none)"
+    if machine_profile_matches; then
+        printf 'Profile match:    yes\n'
+    else
+        printf 'Profile match:    no\n'
+    fi
+
+    printf 'Display manager:  %s\n' "$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null || echo not-configured)"
+    printf 'rEFInd config:    %s\n' "$(find_refind_conf "$(find_esp 2>/dev/null || true)" 2>/dev/null || echo not-detected)"
+    printf 'UEFI BootOrder:   %s\n' "$(current_boot_order 2>/dev/null || echo unavailable)"
+
     printf 'Swap:\n'
     swapon --show 2>/dev/null || true
-    printf 'CanHibernate:   '
-    busctl get-property org.freedesktop.login1 /org/freedesktop/login1 org.freedesktop.login1.Manager CanHibernate 2>/dev/null || true
-    printf 'image_size:     %s\n' "$(cat /sys/power/image_size 2>/dev/null || true)"
-    printf 'ASUS:           '
+
+    printf 'ASUS tools:       '
     asusctl --version 2>/dev/null | head -1 || printf 'not installed\n'
-    printf 'rEFInd ESP:     %s\n' "$(find_esp 2>/dev/null || printf 'not detected')"
-    printf 'Frieren SDDM:   %s\n' "$([[ -d "$MACHINE_DIR/sddm/themes/sddm-frieren-theme" ]] && echo captured || echo not-captured)"
-    printf 'Refresh service:\n'
-    systemctl --user --no-pager --full status auto-refresh-rate.service 2>/dev/null | sed -n '1,5p' || true
-    printf 'Saved packages: pacman=%s aur=%s\n' \
-        "$([[ -f "$PKG_DIR/pacman.txt" ]] && echo yes || echo no)" \
-        "$([[ -f "$PKG_DIR/aur.txt" ]] && echo yes || echo no)"
-    printf '\nGPU/NVIDIA/CUDA drivers and Secure-Boot signing remain outside this installer.\n'
+
+    printf 'Refresh service:  '
+    if systemctl --user is-enabled auto-refresh-rate.service >/dev/null 2>&1; then
+        systemctl --user is-active auto-refresh-rate.service 2>/dev/null || true
+    else
+        printf 'disabled\n'
+    fi
+
+    printf '\nSafety model: portable base never auto-restores exact SDDM, rEFInd boot entries, refresh timings, GPU mode, or hibernation.\n'
 }
 
 usage() {
@@ -583,16 +859,20 @@ usage() {
 Usage: ./system-setup.sh COMMAND
 
 Commands:
-  capture      Sync dotfiles + package lists + sanitized rEFInd + machine info
-  packages     Restore saved pacman/AUR package lists
-  asus         Install generic ASUS laptop support
-  g16          ASUS ROG Zephyrus G16 extras
-  refind       Install/restore rEFInd and rEFInd-minimal theme
-  sddm         Restore exact Frieren SDDM theme and config
-  refresh      Enable 120/240 Hz AC/battery refresh service
-  hibernate    Configure the 20G Btrfs hibernation swap setup
-  status       Show current setup status
-  all          packages + ASUS + hibernate + optional rEFInd + refresh + status
+  capture       Capture current dotfiles + sanitized machine backups
+  packages      Restore saved pacman/AUR package lists
+  asus          Install generic ASUS laptop support
+  g16           Install safe Zephyrus G16 extras
+  sddm-theme    Install Frieren SDDM theme only; no DM switch/autologin
+  sddm          Exact captured SDDM restore (guarded and explicit)
+  refind        Safe rEFInd install + portable theme + machine-generated options
+  refresh       Enable G16 refresh service only after panel/session checks
+  hibernate     Configure Btrfs hibernation swap storage (explicit)
+  status        Show current setup status
+
+Environment overrides:
+  DOTFILES_FORCE_MACHINE_PROFILE=1   bypass machine-profile guards
+  DOTFILES_SWAP_SIZE=20G             hibernation swap size
 EOF
 }
 
@@ -602,23 +882,12 @@ main() {
         packages) restore_packages ;;
         asus) setup_asus ;;
         g16) setup_g16 ;;
+        sddm-theme) install_sddm_theme_only ;;
+        sddm) restore_sddm_exact ;;
         refind) setup_refind ;;
-        sddm) restore_sddm ;;
         refresh) enable_refresh ;;
         hibernate) setup_hibernate ;;
         status) status_report ;;
-        all)
-            restore_packages
-            setup_asus
-            setup_hibernate
-            if ! secure_boot_enabled; then
-                prompt_yes_no "Set up rEFInd?" n && setup_refind
-            else
-                warn "Secure Boot enabled; skipping rEFInd customization."
-            fi
-            prompt_yes_no "Enable 120/240 Hz refresh automation?" y && enable_refresh
-            status_report
-            ;;
         -h|--help|help|"") usage ;;
         *) die "Unknown command: $1" ;;
     esac


### PR DESCRIPTION
## Why

The current one-command installer mixes portable dotfiles with captured machine-specific state. On another laptop this can restore the captured SDDM configuration and later copy/derive boot settings that belong to the original Zephyrus G16. The rEFInd wrapper also re-used the ESP path detected before `refind-install`, which can miss the actual `refind.conf` location after installation.

## What this changes

- Makes `--base` portable-only: no automatic SDDM restore, rEFInd, GPU mode, refresh-rate activation, or hibernation.
- Makes `--all` a safe profile: portable base + detected ASUS/G16 package support only.
- Adds a theme-only SDDM path that never enables/replaces the display manager or restores autologin.
- Keeps exact SDDM restore available only as an explicit, machine-profile-guarded action.
- Reworks rEFInd setup to:
  - verify UEFI / Secure Boot state;
  - detect the mounted FAT ESP;
  - preserve the existing UEFI BootOrder;
  - re-detect the ESP and `refind.conf` after `refind-install`;
  - restore the previous BootOrder on failure;
  - apply only the portable rEFInd-minimal theme instead of the captured full boot config;
  - generate current-machine kernel options with `mkrlconf` when possible;
  - leave rEFInd as default only when explicitly requested.
- Removes the hard-coded `/dev/nvme0n1p5` root device from the captured `refind_linux.conf`.
- Gates the G16 refresh service behind G16 + active Hyprland + expected internal panel checks.
- Keeps GPU switching manual.
- Makes hibernation explicit and adds filesystem/free-space/RAM checks.
- Stops deploying Fish universal variables as portable dotfiles.
- Adds installer documentation and a GitHub Actions Bash syntax check.

## Safety note

This deliberately keeps `machine/` as a backup of the original machine, not as a universal profile. Exact machine-state restoration remains possible only through explicit guarded commands.
